### PR TITLE
fix: Burnable NullReferenceException fix

### DIFF
--- a/Assets/Scripts/Objects/Burnable.cs
+++ b/Assets/Scripts/Objects/Burnable.cs
@@ -19,18 +19,18 @@ public class Burnable : MonoBehaviour
 
     public event UnityAction Burned;
 
-    private Campfire _campfire;
     private Collider _collider;
     private CoherenceSync _sync;
     private bool _hasBurned;
     private float _creationTime;
     private readonly float _selfDestructTime = 1800f;
 
+    private Campfire Campfire => Campfire.Instance;
+
     private void Awake()
     {
         _sync = GetComponent<CoherenceSync>();
         _collider = GetComponent<Collider>();
-        _campfire = FindObjectOfType<Campfire>();
     }
 
     private void OnEnable()
@@ -51,7 +51,7 @@ public class Burnable : MonoBehaviour
 
     private void CheckFireplaceCollisions()
     {
-        if (_collider.bounds.Intersects(_campfire.CollisionBounds))
+        if (_collider.bounds.Intersects(Campfire.CollisionBounds))
         {
             GetBurned();
         }
@@ -59,7 +59,7 @@ public class Burnable : MonoBehaviour
 
     private void GetBurned()
     {
-        _campfire.BurnObjectLocal(_sync);
+        Campfire.BurnObjectLocal(_sync);
         Remove();
     }
 

--- a/Assets/Scripts/Objects/Campfire.cs
+++ b/Assets/Scripts/Objects/Campfire.cs
@@ -9,6 +9,26 @@ using Coherence.Toolkit;
 /// </summary>
 public class Campfire : MonoBehaviour
 {
+    private static Campfire _instance;
+
+    public static Campfire Instance
+    {
+        get
+        {
+            if(!_instance)
+            {
+                _instance =
+#if UNITY_6000_0_OR_NEWER || UNITY_2022_3 || UNITY_2021_3
+                    FindAnyObjectByType<Campfire>(FindObjectsInactive.Exclude);
+#else
+                    FindObjectOfType<Campfire>();
+#endif
+            }
+
+            return _instance;
+        }
+    }
+
     [Header("Runtime state")]
     [Sync] public int activeFireEffect;
     [Sync] public float fireTimer; // Time left to burn before fire goes off
@@ -37,11 +57,12 @@ public class Campfire : MonoBehaviour
     private Collider _collider;
     private CoherenceSync _sync;
     private float _teamEffortTimer; // Time left to put another item on the fire, to provoke a big fire 
-    
+
     private bool IsBigFireOn => bigFireTimer > 0;
 
     private void Awake()
     {
+        _instance = this;
         _collider = GetComponent<Collider>();
         _sync = GetComponent<CoherenceSync>();
         
@@ -123,6 +144,8 @@ public class Campfire : MonoBehaviour
             }
         }
     }
+    
+    private void OnDisable() => _instance = null;
 
     /// <summary>
     /// Invoked locally by a <see cref="Burnable"/> that collided with the campfire. Can be on the campfire authority, or not.

--- a/Assets/Scripts/Objects/Campfire.cs
+++ b/Assets/Scripts/Objects/Campfire.cs
@@ -62,12 +62,12 @@ public class Campfire : MonoBehaviour
 
     private void Awake()
     {
-        _instance = this;
         _collider = GetComponent<Collider>();
         _sync = GetComponent<CoherenceSync>();
-        
         _sync.CoherenceBridge.onLiveQuerySynced.AddListener(OnLiveQuerySynced);
     }
+
+    private void OnEnable() => _instance = this;
 
     /// <summary>
     /// If this build is being run as a Simulator, the Simulator takes authority over the campfire.
@@ -144,7 +144,7 @@ public class Campfire : MonoBehaviour
             }
         }
     }
-    
+
     private void OnDisable() => _instance = null;
 
     /// <summary>


### PR DESCRIPTION
### What does this fix
#7307

### What has changed
Fixed issue where the Campfire component referenced by all Burnable instances could get destroyed and replaced by another instance, resulting in NullReferenceExceptions. The singleton pattern was used to automatically update the reference when needed.