### PR TITLE
fix: Burnable NullReferenceException fix

### DIFF
--- a/Assets/Scripts/Objects/Burnable.cs
+++ b/Assets/Scripts/Objects/Burnable.cs
@@ -25,8 +25,6 @@ public class Burnable : MonoBehaviour
     private float _creationTime;
     private readonly float _selfDestructTime = 1800f;
 
-    private Campfire Campfire => Campfire.Instance;
-
     private void Awake()
     {
         _sync = GetComponent<CoherenceSync>();
@@ -51,15 +49,15 @@ public class Burnable : MonoBehaviour
 
     private void CheckFireplaceCollisions()
     {
-        if (_collider.bounds.Intersects(Campfire.CollisionBounds))
+        if (Campfire.TryGet(out var campfire) && _collider.bounds.Intersects(campfire.CollisionBounds))
         {
-            GetBurned();
+            Burn(campfire);
         }
     }
 
-    private void GetBurned()
+    private void Burn(Campfire campfire)
     {
-        Campfire.BurnObjectLocal(_sync);
+	    campfire.BurnObjectLocal(_sync);
         Remove();
     }
 
@@ -68,7 +66,7 @@ public class Burnable : MonoBehaviour
         // Informs GrabAction to invoke LetGo,
         // so if a player is carrying the object it will be as if they had released it
         Burned?.Invoke();
-        
+
         _hasBurned = true; // Prevents more campfire collisions
         GetComponent<Grabbable>().isBeingCarried = true; // Prevents pickup requests (GrabAction)
         GetComponentInChildren<Interactable>().SetCollider(false); // Prevents object highlighting (InteractionInput)

--- a/Assets/Scripts/Objects/Campfire.cs
+++ b/Assets/Scripts/Objects/Campfire.cs
@@ -11,24 +11,6 @@ public class Campfire : MonoBehaviour
 {
     private static Campfire _instance;
 
-    public static Campfire Instance
-    {
-        get
-        {
-            if(!_instance)
-            {
-                _instance =
-#if UNITY_6000_0_OR_NEWER || UNITY_2022_3 || UNITY_2021_3
-                    FindAnyObjectByType<Campfire>(FindObjectsInactive.Exclude);
-#else
-                    FindObjectOfType<Campfire>();
-#endif
-            }
-
-            return _instance;
-        }
-    }
-
     [Header("Runtime state")]
     [Sync] public int activeFireEffect;
     [Sync] public float fireTimer; // Time left to burn before fire goes off
@@ -59,6 +41,21 @@ public class Campfire : MonoBehaviour
     private float _teamEffortTimer; // Time left to put another item on the fire, to provoke a big fire 
 
     private bool IsBigFireOn => bigFireTimer > 0;
+    
+    public static bool TryGet(out Campfire campfire)
+    {
+        if(!_instance)
+        {
+            _instance =
+#if UNITY_6000_0_OR_NEWER || UNITY_2022_3 || UNITY_2021_3
+                FindAnyObjectByType<Campfire>(FindObjectsInactive.Exclude);
+#else
+                FindObjectOfType<Campfire>();
+#endif
+        }
+
+        return campfire = _instance;
+    }
 
     private void Awake()
     {


### PR DESCRIPTION
## What does this fix
#7307

## What has changed
Burnable will now only try to check for collisions against the Campfire object during FixedUpdate if a Campfire object exists in the scene at that moment. This is to avoid NullReferenceExceptions from occurring.